### PR TITLE
overdue list filter amendment

### DIFF
--- a/plugins/projectify/tiddlers/ui/buttons/Scheduled.tid
+++ b/plugins/projectify/tiddlers/ui/buttons/Scheduled.tid
@@ -17,7 +17,7 @@ type: text/vnd.tiddlywiki
   <$list filter="[<tv-config-toolbar-icons>match[yes]]">
     <span class="py-pill-container">
       {{$:/plugins/nico/projectify/images/calendar-check}}
-      <$list filter="[!has[draft.of]!tag[done]tag[todo]days:due[0]limit[1]]">
+      <$list filter="[[days:due[0]] [!days:due[-1]] +[!has[draft.of]!tag[done]tag[todo]limit[1]]">
         <div class="py-pill"></div>
       </$list>
     </span>


### PR DESCRIPTION
[days:due[0]] contrary to what we expect, only gives those tiddlers due today, on this day only, tiddlers due yesterday or before are omitted

[!days:due[-1]] gets the tiddlers that were due yesterday and before

so we need them both i think (or is this not the intended behaviour for the core filter?)

sorry for any typos i am cloning on mobile! also first time using the pull request on mobile, sorry if i've done it the wrong way

warmest wishes, maki