### PR TITLE
download and save with a correct name

### DIFF
--- a/editions/website/tiddlers/$__config_SaveWikiButton_Filename.tid
+++ b/editions/website/tiddlers/$__config_SaveWikiButton_Filename.tid
@@ -1,0 +1,6 @@
+created: 20210109043935928
+modified: 20210109044020375
+tags: 
+title: $:/config/SaveWikiButton/Filename
+
+Projectify {{$:/plugins/nico/projectify!!version}}.html


### PR DESCRIPTION
This config tiddler lets to download and save the projectify wiki (not plugin) with a pre specified name. At the moment it is downloaded with `tiddlywiki.html` name.

Ref: https://tiddlywiki.com/#Hidden%20Setting%3A%20Filename%20for%20Save%20Wiki%20Button